### PR TITLE
Changed platform SDK version back to 10069

### DIFF
--- a/Shield.Communication/Shield.Communication.csproj
+++ b/Shield.Communication/Shield.Communication.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>Shield.Communication</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10074.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10074.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.10069.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.10069.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Shield.Core/Shield.Core.csproj
+++ b/Shield.Core/Shield.Core.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>Shield.Core</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10074.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10074.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.10069.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.10069.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Shield/App.xaml
+++ b/Shield/App.xaml
@@ -22,7 +22,7 @@
     THE SOFTWARE.
 -->
 
-﻿<Application
+<Application
     x:Class="Shield.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Shield/MainPage.xaml
+++ b/Shield/MainPage.xaml
@@ -22,7 +22,7 @@
     THE SOFTWARE.
 -->
 
-﻿<Page
+<Page
     x:Class="Shield.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Shield/SettingsPage.xaml
+++ b/Shield/SettingsPage.xaml
@@ -22,7 +22,7 @@
     THE SOFTWARE.
 -->
 
-﻿<Page
+<Page
     x:Class="Shield.SettingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -30,7 +30,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-    
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -42,7 +42,7 @@
                 Visibility="{Binding Source={StaticResource appSettings}, Path=MissingBackButton, Converter={StaticResource BoolToVisConverter}}">
             <Image Source="Assets/left.png" Width="32" Height="32" Stretch="UniformToFill"/>
         </Button>
-        
+
         <TextBlock Grid.Row="1" Margin="12,12,0,0" Text="SETTINGS" FontSize="16" FontFamily="Segoe UI Light"/>
         <Pivot Grid.Row="2" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
             <PivotItem>
@@ -68,7 +68,7 @@
                         <TextBox x:Name="serverClientHostNameTextBox" PlaceholderText="HostName or IP address"  Width="auto" Text="{Binding Source={StaticResource appSettings}, Path=Hostname, Mode=TwoWay}" />
                         <TextBox x:Name="serverClientHostServiceTextBox" PlaceholderText="HostPort"  Width="auto" Text="{Binding Source={StaticResource appSettings}, Path=Hostport, Mode=TwoWay}" />
                     </StackPanel>-->
-                    
+
                     <StackPanel Grid.Row="0" x:Name="ConnectStackParent" Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <TextBlock x:Name="ChooseMessage" FontSize="16" Width="Auto" VerticalAlignment="Bottom" TextWrapping="Wrap"
                                    Visibility="{Binding Source={StaticResource appSettings}, Path=ListVisible, Converter={StaticResource BoolToVisConverter}}"
@@ -172,5 +172,5 @@
             </PivotItem>
         </Pivot>
     </Grid>
-    
+
 </Page>

--- a/Shield/Shield.csproj
+++ b/Shield/Shield.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>Shield</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10074.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10074.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.10069.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.10069.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
Since the latest public version of the platform SDK (which is also installed by VS 2015 RC) is 10069, the project files must contain that number, or they wont be opened in Visual Studio.