### PR TITLE
Remove references to Removed reference to Shield_Storekey.pfx (caused build to fail)

### DIFF
--- a/Shield/Shield.csproj
+++ b/Shield/Shield.csproj
@@ -22,8 +22,6 @@
     <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
     <AppxBundle>Always</AppxBundle>
     <AppxBundlePlatforms>neutral</AppxBundlePlatforms>
-    <PackageCertificateThumbprint>CF6901192EFC8BB1E66A28C5E053FB8A8D9F750A</PackageCertificateThumbprint>
-    <PackageCertificateKeyFile>Shield_StoreKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Shield/Shield.csproj
+++ b/Shield/Shield.csproj
@@ -144,7 +144,6 @@
     </AppxManifest>
     <None Include="ApplicationInsights.config" />
     <None Include="packages.config" />
-    <None Include="Shield_StoreKey.pfx" />
     <PRIResource Include="Strings\en-US\Resources.resw" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This caused my first build to fail. Any objection to removing the references to Shield_Storekey.pfx from the project so others are not impacted? 