### PR TITLE
Update telemetry approach to match remote-wiring-experience

### DIFF
--- a/Shield/App.xaml.cs
+++ b/Shield/App.xaml.cs
@@ -37,6 +37,7 @@ using Windows.Storage;
 using Windows.UI.Notifications;
 using Shield.Core.Models;
 using System.IO;
+using Microsoft.ApplicationInsights;
 
 // The Blank Application template is documented at http://go.microsoft.com/fwlink/?LinkId=402347&clcid=0x409
 
@@ -72,6 +73,8 @@ namespace Shield
             {
                 // on device which doesn't have it... (core)
             }
+
+            Telemetry = new TelemetryClient();
         }
 
         private void App_UnhandledException(object sender, UnhandledExceptionEventArgs e)
@@ -212,6 +215,10 @@ namespace Shield
             deferral.Complete();
         }
 
-        
+        public static TelemetryClient Telemetry
+        {
+            get;
+            private set;
+        }
     }
 }

--- a/Shield/MainPage.xaml.cs
+++ b/Shield/MainPage.xaml.cs
@@ -72,7 +72,6 @@ namespace Shield
         private AppSettings appSettings = null;
 
         public static MainPage Instance = null;
-        private TelemetryClient telemetry = new TelemetryClient();
 
         private Screen screen;
         private Web web;
@@ -376,7 +375,7 @@ namespace Shield
             }
             catch (Exception ex)
             {
-                telemetry.TrackException(ex);
+                App.Telemetry.TrackException(ex);
                 return;
             }
 
@@ -384,7 +383,7 @@ namespace Shield
             {
                 await dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    telemetry.TrackEvent("VirtualShieldConnectionEnumerationFail");
+                    App.Telemetry.TrackEvent("VirtualShieldConnectionEnumerationFail");
                 });
 
                 return;
@@ -400,7 +399,7 @@ namespace Shield
             await dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
                 appSettings.ConnectionList = connections;
-                telemetry.TrackEvent("VirtualShieldConnectionEnumerationSuccess");
+                App.Telemetry.TrackEvent("VirtualShieldConnectionEnumerationSuccess");
             });
         }
 
@@ -421,7 +420,7 @@ namespace Shield
                     appSettings.CurrentConnectionState = (int)ConnectionState.NotConnected;
                 });
 
-                telemetry.TrackEvent("VirtualShieldDisconnect");
+                App.Telemetry.TrackEvent("VirtualShieldDisconnect");
             }
         }
 
@@ -449,14 +448,14 @@ namespace Shield
                     if (!worked)
                     {
                         appSettings.CurrentConnectionState = (int)ConnectionState.CouldNotConnect;
-                        telemetry.TrackEvent("VirtualShieldConnectionFail");
+                        App.Telemetry.TrackEvent("VirtualShieldConnectionFail");
                     }
                     else
                     {
                         appSettings.CurrentConnectionState = (int)ConnectionState.Connected;
                         currentConnection = selectedConnection;
                         appSettings.PreviousConnectionName = currentConnection.DisplayName;
-                        telemetry.TrackEvent("VirtualShieldConnectionSuccess");
+                        App.Telemetry.TrackEvent("VirtualShieldConnectionSuccess");
                         result = true;
                     }
                 });
@@ -475,7 +474,7 @@ namespace Shield
                 {
                     appSettings.CurrentConnectionState = (int)ConnectionState.CouldNotConnect;
                 });
-                telemetry.TrackException(e);
+                App.Telemetry.TrackException(e);
             }
 
             return result;
@@ -483,6 +482,7 @@ namespace Shield
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
+            App.Telemetry.TrackPageView("MainPage");
             InitializeManager();
 
             if ((!appSettings.AutoConnect || string.IsNullOrWhiteSpace(appSettings.PreviousConnectionName))

--- a/Shield/MainPageHandleMessage.cs
+++ b/Shield/MainPageHandleMessage.cs
@@ -179,7 +179,7 @@ namespace Shield
                 if (message.Service != "SYSTEM")
                 {
                     var dictionary = new Dictionary<string, string> {{"Type", message.Service}};
-                    telemetry.TrackEvent("MessageInfo", dictionary);
+                    App.Telemetry.TrackEvent("MessageInfo", dictionary);
                 }
             }
             catch (Exception)
@@ -195,7 +195,7 @@ namespace Shield
                     if (message.Action.Equals("PONG"))
                     {
                         var totalRoundTrip = recentStringReceivedTick - sentPingTick;
-                        telemetry.TrackMetric("VirtualShieldPingPongTimeDifferenceMillisec",
+                        App.Telemetry.TrackMetric("VirtualShieldPingPongTimeDifferenceMillisec",
                             totalRoundTrip/TimeSpan.TicksPerMillisecond);
                     }
                     else if (message.Action.Equals("START"))
@@ -863,7 +863,7 @@ namespace Shield
                         throw new UnsupportedSensorException("Accelerometer does not exist");
                     }
 
-                    telemetry.TrackEvent("Sensor", new Dictionary<string, string> {{"A", sensorItem.A.Value.ToString()}});
+                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> {{"A", sensorItem.A.Value.ToString()}});
                     Sensors.SensorSwitches.A = sensorItem.A.Value;
                 }
                 else if (sensorItem.G != null)
@@ -874,7 +874,7 @@ namespace Shield
                         throw new UnsupportedSensorException("Gyrometer does not exist");
                     }
 
-                    telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "G", sensorItem.G.Value.ToString() } });
+                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "G", sensorItem.G.Value.ToString() } });
                     Sensors.SensorSwitches.G = sensorItem.G.Value;
                 }
                 else if (sensorItem.M != null)
@@ -885,7 +885,7 @@ namespace Shield
                         throw new UnsupportedSensorException("Compass does not exist");
                     }
 
-                    telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "M", sensorItem.M.Value.ToString() } });
+                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "M", sensorItem.M.Value.ToString() } });
                     Sensors.SensorSwitches.M = sensorItem.M.Value;
                 }
                 else if (sensorItem.L != null)
@@ -901,7 +901,7 @@ namespace Shield
                         throw new UnsupportedSensorException("OrientationSensor does not exist");
                     }
 
-                    telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "Q", sensorItem.Q.Value.ToString() } });
+                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "Q", sensorItem.Q.Value.ToString() } });
                     Sensors.SensorSwitches.Q = sensorItem.Q.Value;
                 }
                 else if (sensorItem.P != null)
@@ -912,7 +912,7 @@ namespace Shield
                         throw new UnsupportedSensorException("LightSensor does not exist");
                     }
 
-                    telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "P", sensorItem.P.Value.ToString() } });
+                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "P", sensorItem.P.Value.ToString() } });
                     Sensors.SensorSwitches.P = sensorItem.P.Value;
                 }
 

--- a/Shield/SettingsPage.xaml.cs
+++ b/Shield/SettingsPage.xaml.cs
@@ -55,6 +55,7 @@ namespace Shield
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
+            App.Telemetry.TrackPageView("SettingsPage");
             main.IsInSettings = true;
             main.RefreshConnections();
             base.OnNavigatedTo(e);

--- a/Shield/project.json
+++ b/Shield/project.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "dependencies": {
     "HtmlAgilityPack": "1.4.9",
     "Microsoft.ApplicationInsights": "1.0.0",


### PR DESCRIPTION
Main change is to log a PageView telemetry event when either the main page or the settings page are loaded.  Moved the telemetry client object to be statically defined at the application level, so it can be used across pages/classes.