### PR TITLE
Fixes for telemetry

### DIFF
--- a/Shield/App.xaml.cs
+++ b/Shield/App.xaml.cs
@@ -38,6 +38,7 @@ using Windows.UI.Notifications;
 using Shield.Core.Models;
 using System.IO;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
 
 // The Blank Application template is documented at http://go.microsoft.com/fwlink/?LinkId=402347&clcid=0x409
 
@@ -55,6 +56,13 @@ namespace Shield
         /// </summary>
         public App()
         {
+            WindowsAppInitializer.InitializeAsync()
+                .ContinueWith(task =>
+                {
+                    TelemetryConfiguration.Active.TelemetryInitializers.Add(new UwpDeviceTelemetryInitializer());
+                })
+                .ContinueWith(task => { Telemetry = new TelemetryClient(); });
+
             InitializeComponent();
             Suspending += OnSuspending;
             Resuming += OnResuming;
@@ -73,8 +81,6 @@ namespace Shield
             {
                 // on device which doesn't have it... (core)
             }
-
-            Telemetry = new TelemetryClient();
         }
 
         private void App_UnhandledException(object sender, UnhandledExceptionEventArgs e)
@@ -133,6 +139,8 @@ namespace Shield
             // just ensure that the window is active
             if (rootFrame == null)
             {
+                Telemetry.TrackEvent("Launch");
+                
                 // Create a Frame to act as the navigation context and navigate to the first page
                 rootFrame = new Frame();
                 // Set the default language

--- a/Shield/ApplicationInsights.config
+++ b/Shield/ApplicationInsights.config
@@ -1,3 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ApplicationInsights xmlns = "http://schemas.microsoft.com/ApplicationInsights/2013/Settings">
+  <!-- This key is for Application Insights resource 'Virtual Shields for Arduino - Public' in resource group 'AppInsights-MakerProjects' -->
+  <InstrumentationKey>1006745a-e3fb-4a74-b299-fc233e91b14c</InstrumentationKey>
 </ApplicationInsights>

--- a/Shield/MainPageHandleMessage.cs
+++ b/Shield/MainPageHandleMessage.cs
@@ -863,7 +863,7 @@ namespace Shield
                         throw new UnsupportedSensorException("Accelerometer does not exist");
                     }
 
-                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> {{"A", sensorItem.A.Value.ToString()}});
+                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> {{"sensor.type", sensorsMessage.Type.ToString()}, { "sensor.value", sensorItem.A.Value.ToString()}});
                     Sensors.SensorSwitches.A = sensorItem.A.Value;
                 }
                 else if (sensorItem.G != null)
@@ -874,7 +874,7 @@ namespace Shield
                         throw new UnsupportedSensorException("Gyrometer does not exist");
                     }
 
-                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "G", sensorItem.G.Value.ToString() } });
+                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "sensor.type", sensorsMessage.Type.ToString() }, { "sensor.value", sensorItem.G.Value.ToString() } });
                     Sensors.SensorSwitches.G = sensorItem.G.Value;
                 }
                 else if (sensorItem.M != null)
@@ -885,13 +885,13 @@ namespace Shield
                         throw new UnsupportedSensorException("Compass does not exist");
                     }
 
-                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "M", sensorItem.M.Value.ToString() } });
-                    Sensors.SensorSwitches.M = sensorItem.M.Value;
+                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "sensor.type", sensorsMessage.Type.ToString() }, { "sensor.value", sensorItem.M.Value.ToString() } }); Sensors.SensorSwitches.M = sensorItem.M.Value;
                 }
                 else if (sensorItem.L != null)
                 {
                     sensorsMessage.Type = 'L';
                     Sensors.SensorSwitches.L = sensorItem.L.Value;
+                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "sensor.type", sensorsMessage.Type.ToString() }, { "sensor.value", sensorItem.L.Value.ToString() } });
                 }
                 else if (sensorItem.Q != null)
                 {
@@ -901,7 +901,7 @@ namespace Shield
                         throw new UnsupportedSensorException("OrientationSensor does not exist");
                     }
 
-                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "Q", sensorItem.Q.Value.ToString() } });
+                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "sensor.type", sensorsMessage.Type.ToString() }, { "sensor.value", sensorItem.Q.Value.ToString() } });
                     Sensors.SensorSwitches.Q = sensorItem.Q.Value;
                 }
                 else if (sensorItem.P != null)
@@ -912,7 +912,7 @@ namespace Shield
                         throw new UnsupportedSensorException("LightSensor does not exist");
                     }
 
-                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "P", sensorItem.P.Value.ToString() } });
+                    App.Telemetry.TrackEvent("Sensor", new Dictionary<string, string> { { "sensor.type", sensorsMessage.Type.ToString() }, { "sensor.value", sensorItem.P.Value.ToString() } });
                     Sensors.SensorSwitches.P = sensorItem.P.Value;
                 }
 

--- a/Shield/SettingsPage.xaml.cs
+++ b/Shield/SettingsPage.xaml.cs
@@ -55,7 +55,6 @@ namespace Shield
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            App.Telemetry.TrackPageView("SettingsPage");
             main.IsInSettings = true;
             main.RefreshConnections();
             base.OnNavigatedTo(e);

--- a/Shield/Shield.csproj
+++ b/Shield/Shield.csproj
@@ -127,6 +127,7 @@
     <Compile Include="SettingsPage.xaml.cs">
       <DependentUpon>SettingsPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="UwpDeviceTelemetryInitializer.cs" />
     <Compile Include="ViewModels\MainViewModel.cs" />
     <Compile Include="ViewModels\ViewModelLocator.cs" />
   </ItemGroup>

--- a/Shield/UwpDeviceTelemetryInitializer.cs
+++ b/Shield/UwpDeviceTelemetryInitializer.cs
@@ -1,0 +1,34 @@
+﻿
+namespace Shield
+{
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    /// <summary>
+    /// TelemetryInitializer to improve Device Family and Device Type telemetry for ApplicationInsights
+    /// </summary>
+    public class UwpDeviceTelemetryInitializer : ITelemetryInitializer
+    {
+        public void Initialize(Microsoft.ApplicationInsights.Channel.ITelemetry telemetry)
+        {
+            telemetry.Context.Properties["device.family"] = Windows.System.Profile.AnalyticsInfo.VersionInfo.DeviceFamily;
+
+            // AppInsights *always* sets Device.Type to "Phone" for a UWP application.  Override with
+            // a more useful value.
+            switch (telemetry.Context.Properties["device.family"])
+            {
+                case "Windows.Desktop":
+                    telemetry.Context.Device.Type = "PC";
+                    break;
+                case "Windows.Mobile":
+                    telemetry.Context.Device.Type = "Phone";
+                    break;
+                case "Windows.IoT":
+                    telemetry.Context.Device.Type = "IoT";
+                    break;
+                default:
+                    telemetry.Context.Device.Type = "Other";
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Properly call WindowsAppInitializer to set up telemetry providers
- Add event for application launch
- Add standardized events for connections
- Add custom TelemetryInitializer to fix device.type and add device.family