### PR TITLE
Fix header Markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿
 
-#Windows Virtual Shields for Arduino (Universal Windows App)
+# Windows Virtual Shields for Arduino (Universal Windows App)
 
 This project lets your Arduino sketch control your Windows 10 device (phone). The only code you write is to an Arduino sketch.
 
@@ -36,7 +36,7 @@ Capabilities:
   * Regular expressions
   * Table iteration (keys/values saved)
 
-##Within your Arduino Wiring Sketch, you can enable the following scenarios:
+## Within your Arduino Wiring Sketch, you can enable the following scenarios:
 
 * Place buttons on your Windows Phone's screen which directly affect pins, motors on your Arduino.
   * Shields used:
@@ -58,14 +58,14 @@ Capabilities:
      * Camera
      * Microphone 
 
-##Getting Started : Hardware
+## Getting Started : Hardware
 
-###What you need 
+### What you need 
  1. Arduino Uno or compatible device.
  2. Bluetooth module: SparkFun BlueSMiRF Silver (https://www.sparkfun.com/products/12577) and 4 wires to connect.
  3. Windows 10 phone ([Lumia 520](http://www.microsoft.com/en-us/mobile/phone/lumia520/), [Lumia 635](http://www.microsoft.com/en-us/mobile/phone/lumia635/))
 
-###Set up your Arduino [using the Windows Virtual Shields for Arduino library](https://github.com/ms-iot/virtual-shields-arduino/)
+### Set up your Arduino [using the Windows Virtual Shields for Arduino library](https://github.com/ms-iot/virtual-shields-arduino/)
  1. Prepare the Bluetooth module if necessary (the Bluetooth module may need to have headers soldered onto it).
  2. Except for one difference below, connect the Bluetooth module to the Arduino per your wiring diagram ([BlueSMiRF wiring diagram](https://learn.sparkfun.com/tutorials/using-the-bluesmirf/hardware-hookup)).
     
@@ -73,33 +73,33 @@ Capabilities:
         The Bluetooth TX should connect to pin 0 (Arduino RX).  
         The Bluetooth RX should connect to pin 1 (Arduino TX).  
 
-###Set up your Windows 10 phone
+### Set up your Windows 10 phone
  1. Windows 8 users can get the "Windows Insider" application from the app store. This allows the user to opt into receiving Windows 10 Technical Previews as updates.
  2. Pair the Bluetooth device in the Bluetooth settings.  
     BlueSMiRF default pin code is 1234.  
     NOTE: The red blinking light on the BlueSMiRF continues to blink red after a successful pairing. This is expected. It only turns green after a connecting with the application.  
     When pairing you should see a device name like "RNBT-76BC" the last four characters are the last four characters of the MAC address printed on the sticker of the module.  
 
-##Getting Started : Software
+## Getting Started : Software
 
-###What you need
+### What you need
  1. Arduino IDE 1.6 or better.
  2. ArduinoJson library.
  3. This repository.
  4. Visual Studio 2015 to sideload UWA (phone app) onto developer unlocked phone.
 
-###Set up your Arduino IDE [using the Windows Virtual Shields for Arduino library](https://github.com/ms-iot/virtual-shields-arduino/)
+### Set up your Arduino IDE [using the Windows Virtual Shields for Arduino library](https://github.com/ms-iot/virtual-shields-arduino/)
  1. Download and install the [Arduino IDE](http://www.arduino.cc/en/Main/Software).
 
-###Set up ArduinoJson library [using the Windows Virtual Shields for Arduino library](https://github.com/ms-iot/virtual-shields-arduino/)
+### Set up ArduinoJson library [using the Windows Virtual Shields for Arduino library](https://github.com/ms-iot/virtual-shields-arduino/)
  1. From the [ArduinoJson repository](https://github.com/bblanchon/ArduinoJson), branch the reporsitory or download the zip.
  2. Place the whole repository into your libraries folder (i.e. Documents\Arduino\libraries\ArduinoJson\).
 
-###Set up this repository. [using the Windows Virtual Shields for Arduino library](https://github.com/ms-iot/virtual-shields-arduino/)
+### Set up this repository. [using the Windows Virtual Shields for Arduino library](https://github.com/ms-iot/virtual-shields-arduino/)
  1. Branch this repository or download the zip.
  2.	Copy the Arduino/libraries/VirtualShield folder from your repository to your Arduino library (i.e. Documents\Arduino\libraries\VirtualShield\).
 
-###Set up your Visual Studio 2015
+### Set up your Visual Studio 2015
  1. Get the Windows 10 Technical Preview tools, including Visual Studio 2015 from [dev.windows.com](https://dev.windows.com/en-us/windows-10-developer-preview-tools).
  2. Load the Shield.sln from this repository (<repository>/Shield/Shield.sln).
  3. Ensure your phone is developer-unlocked [run the Windows Phone Developer Registration tool installed with the tools](https://msdn.microsoft.com/en-us/library/windows/apps/dn614128.aspx). 
@@ -107,7 +107,7 @@ Capabilities:
  5. Run the Virtual Shields for Arduino application.
  6. In the app settings, find your previously paired Bluetooth device and Connect.
 
-###Test your setup
+### Test your setup
  1. From the Arduino IDE, go to the menu item File->Examples->Virtual Shields->Hello Blinky. This should load the Hello Blinky example.
  2. Before downloading, temporarily remove the Bluetooth TX and RX wires from the Arduino. (There is only one serial port shared between the USB and Bluetooth. The Bluetooth interferes with the download).
  3. Download the sketch.
@@ -115,7 +115,7 @@ Capabilities:
  5. Press the Reset button on the Arduino to restart the sketch.
  6. (You should see a message on your phone and be able to interact).
 
-##Troubleshooting:
+## Troubleshooting:
 *	Did you build a custom sketch? Remember to include “ shield.begin() “ in your setup():
 
 ```c++
@@ -131,7 +131,7 @@ Capabilities:
 *	Double check that your Bluetooth’s TX pin is connected to your Arduino’s RX pin and that the Bluetooth’s RX pin is connected to your Arduino’s TX pin per this [diagram](https://learn.sparkfun.com/tutorials/using-the-bluesmirf/hardware-hookup).
 *	Is there another strong broadcasting Bluetooth device around, like headphones or a Bluetooth mouse? This can interfere.
 
-##Arduino Wiring Sketch : Hello World example
+## Arduino Wiring Sketch : Hello World example
 
 ```c++
 


### PR DESCRIPTION
GitHub's Markdown interpreter was recently changed to strictly enforce the [GFM spec](https://github.github.com/gfm/), which requires a delimiting space in header Markdown. This has caused some Markdown to no longer display as originally intended.

More information:
https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown
https://github.com/github/markup/issues/1013